### PR TITLE
Обновлен файл requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,6 @@
 redis==4.4.2
 elasticsearch[async]==7.9.1
-fastapi==0.61.1
-orjson==3.9.7
-pydantic==1.10.1
+fastapi==0.104.0
+pydantic==2.4.2
 uvicorn==0.12.2
 uvloop==0.17.0 ; sys_platform != "win32" and implementation_name == "cpython"


### PR DESCRIPTION
Чтобы убрать orjson, необходимо установить вторую версию pydantic, и обновить версию fastapi, которая его поддерживает